### PR TITLE
allow events to fail

### DIFF
--- a/Adafruit_Sensor.h
+++ b/Adafruit_Sensor.h
@@ -143,7 +143,7 @@ class Adafruit_Sensor {
 
   // These must be defined by the subclass
   virtual void enableAutoRange(bool enabled) {};
-  virtual void getEvent(sensors_event_t*);
+  virtual bool getEvent(sensors_event_t*);
   virtual void getSensor(sensor_t*);
   
  private:


### PR DESCRIPTION
See related https://github.com/adafruit/Adafruit_LSM303DLHC/pull/9 for logic as to why..

The LSM303 mag registers aren't valid if DRDY isn't set in the status register.  Once set they'll remain valid until all registers are read.  If data is read whilst the LSM303 writes to those registers it'll be junk.  I could have opted to read in a loop until DRDY is set, but depending on the rate set for updates that can be a long time and will prevent other data being processed (e.g. the serial buffer may overflow whilst the magnetometer code spins polling).  Instead I added the ability for getEvent to fail meaning there's no valid data.  I'll also generate a related pull request on Adafruit_Sensor.
