### PR TITLE
Add virtual destructor

### DIFF
--- a/Adafruit_Sensor.cpp
+++ b/Adafruit_Sensor.cpp
@@ -1,5 +1,2 @@
 #include "Adafruit_Sensor.h"
 #include <avr/pgmspace.h>
-
-void Adafruit_Sensor::constructor() {
-}

--- a/Adafruit_Sensor.h
+++ b/Adafruit_Sensor.h
@@ -144,8 +144,8 @@ class Adafruit_Sensor {
 
   // These must be defined by the subclass
   virtual void enableAutoRange(bool enabled) {};
-  virtual bool getEvent(sensors_event_t*);
-  virtual void getSensor(sensor_t*);
+  virtual bool getEvent(sensors_event_t*) = 0;
+  virtual void getSensor(sensor_t*) = 0;
   
  private:
   bool _autoRange;

--- a/Adafruit_Sensor.h
+++ b/Adafruit_Sensor.h
@@ -139,7 +139,7 @@ typedef struct
 class Adafruit_Sensor {
  public:
   // Constructor(s)
-  void constructor();
+  Adafruit_Sensor() {}
   virtual ~Adafruit_Sensor() {}
 
   // These must be defined by the subclass

--- a/Adafruit_Sensor.h
+++ b/Adafruit_Sensor.h
@@ -140,6 +140,7 @@ class Adafruit_Sensor {
  public:
   // Constructor(s)
   void constructor();
+  virtual ~Adafruit_Sensor() {}
 
   // These must be defined by the subclass
   virtual void enableAutoRange(bool enabled) {};


### PR DESCRIPTION
I noticed when writing a child sensor class that the Adafruit_Sensor class doesn't define a destructor. Given that Adafruit_Sensor is meant to be a base class, and that people are likely to interact with its children through Adafruit_Sensor* pointers, it should define a destructor and mark it virtual. Not doing so can cause memory leaks when dynamically allocated children are destroyed. See https://isocpp.org/wiki/faq/virtual-functions#virtual-dtors. 

In the process of fixing this, I also changed a couple of other things that were not actually hurting anything, but I worried were potentially confusing:
* Having a void constructor() method with an empty body does not do anything, and seems likely to confuse people who are new to C++ and don't already have a firm grasp of the distinction between a constructor and a standard method.
* If virtual methods are not implemented in the base class, it is nice to mark them as abstract with a = 0 in the header. This makes it easier for people to see at a glance that the method doesn't have an implementation in the .cpp file, and also can lead to slightly more helpful compiler error messages if they forget to provide an implementation in a derived class (or try to instantiate the base class directly).

Apologies if the latter two are too pedantic!