### PR TITLE
Fixes a compiler warning

### DIFF
--- a/Adafruit_Sensor.h
+++ b/Adafruit_Sensor.h
@@ -143,7 +143,7 @@ class Adafruit_Sensor {
   virtual ~Adafruit_Sensor() {}
 
   // These must be defined by the subclass
-  virtual void enableAutoRange(bool enabled) {};
+  virtual void enableAutoRange(bool) {}
   virtual bool getEvent(sensors_event_t*) = 0;
   virtual void getSensor(sensor_t*) = 0;
   


### PR DESCRIPTION
Fixes the following warning:

/arduino/libraries/Adafruit_Unified_Sensor/Adafruit_Sensor.h:146:37:
warning: unused parameter 'enabled' [-Wunused-parameter]
   virtual void enableAutoRange(bool enabled) {};