### PR TITLE
Suppress unused argument warning in enableAutoRange()

### DIFF
--- a/Adafruit_Sensor.h
+++ b/Adafruit_Sensor.h
@@ -143,7 +143,7 @@ class Adafruit_Sensor {
   virtual ~Adafruit_Sensor() {}
 
   // These must be defined by the subclass
-  virtual void enableAutoRange(bool enabled) {};
+  virtual void enableAutoRange(bool enabled) { (void)enabled; /* suppress unused warning */ };
   virtual bool getEvent(sensors_event_t*) = 0;
   virtual void getSensor(sensor_t*) = 0;
   


### PR DESCRIPTION
For those of us who care about warnings and have them enabled in the Arduino IDE.

Fix the following warning by adding a dummy use of the `enabled` parameter:
```
In file included from .../Documents/Arduino/libraries/Adafruit_BME680_Library/Adafruit_BME680.h:33:0,
                 from .../Documents/Arduino/libraries/Adafruit_BME680_Library/Adafruit_BME680.cpp:30:
.../Documents/Arduino/libraries/Adafruit_Unified_Sensor/Adafruit_Sensor.h:146:16: warning: unused parameter 'enabled' [-Wunused-parameter]
   virtual void enableAutoRange(bool enabled) {
                ^
```

This fixes the same issue as PR#18, but without removing the argument name.