### PR TITLE
Include Adafruit BME280 driver in list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ The following drivers are based on the Adafruit Unified Sensor Driver:
 **Humidity & Temperature**
   - [DHT-sensor-library](https://github.com/adafruit/DHT-sensor-library)
 
+**Humidity, Temperature, & Barometric Pressure**
+  - [Adafruit_BME280_Library](https://github.com/adafruit/Adafruit_BME280_Library/)
+
 **Orientation**
  - [Adafruit_BNO055](https://github.com/adafruit/Adafruit_BNO055)
 


### PR DESCRIPTION
Hoping to help others who get stuck in the [BME280 tutorial](https://learn.adafruit.com/adafruit-bme280-humidity-barometric-pressure-temperature-sensor-breakout/arduino-test) and go searching because they don't have the sensor driver installed.