### PR TITLE
Adding the includes line to the library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=A unified sensor abstraction layer used by many Adafruit sensor librar
 category=Sensors
 url=https://github.com/adafruit/Adafruit_Sensor
 architectures=*
+includes=Adafruit_Sensor.h


### PR DESCRIPTION
This line allows the Arduino framework to discover that this library provides this header file.