### PR TITLE
Remove dependency on `Adafruit ADXL343`

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit Unified Sensor
-version=1.1.2
+version=1.1.3
 author=Adafruit <info@adafruit.com>
 maintainer=Adafruit <info@adafruit.com>
 sentence=Required for all Adafruit Unified Sensor based libraries.
@@ -8,4 +8,3 @@ category=Sensors
 url=https://github.com/adafruit/Adafruit_Sensor
 architectures=*
 includes=Adafruit_Sensor.h
-depends=Adafruit ADXL343


### PR DESCRIPTION
The dependency is the other way around, in that `Adafruit ADXL343`
should depend on `Adafruit Unified Sensor`.