### PR TITLE
Remove redundant ADXL343 dependency

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,3 @@ category=Sensors
 url=https://github.com/adafruit/Adafruit_Sensor
 architectures=*
 includes=Adafruit_Sensor.h
-depends=Adafruit ADXL343


### PR DESCRIPTION
Even it doesn't affect build size, ADXL343 dependency is redundant for the library itself and can confuse end-users.