### PR TITLE
Adafruit_Sensor.h: drop unused private member

### DIFF
--- a/Adafruit_Sensor.h
+++ b/Adafruit_Sensor.h
@@ -216,9 +216,6 @@ public:
   virtual void getSensor(sensor_t *) = 0;
 
   void printSensorDetails(void);
-
-private:
-  bool _autoRange;
 };
 
 #endif


### PR DESCRIPTION
`clang++` is very unhappy about unused private members and, unless told with additional CFLAGS, refuses to compile the code. This makes `clang++` happy again.