### PR TITLE
Add altitude sensor type

### DIFF
--- a/Adafruit_Sensor.cpp
+++ b/Adafruit_Sensor.cpp
@@ -100,6 +100,9 @@ void Adafruit_Sensor::printSensorDetails(void) {
   case SENSOR_TYPE_UNITLESS_PERCENT:
     Serial.print(F("Unitless Percent (%)"));
     break;
+  case SENSOR_TYPE_ALTITUDE:
+    Serial.print(F("Altitude (m)"));
+    break;
   }
 
   Serial.println();

--- a/Adafruit_Sensor.h
+++ b/Adafruit_Sensor.h
@@ -79,7 +79,8 @@ typedef enum {
   SENSOR_TYPE_PM25_ENV = (27),
   SENSOR_TYPE_PM100_ENV = (28),
   SENSOR_TYPE_GAS_RESISTANCE = (29),
-  SENSOR_TYPE_UNITLESS_PERCENT = (30)
+  SENSOR_TYPE_UNITLESS_PERCENT = (30),
+  SENSOR_TYPE_ALTITUDE = (31)
 } sensors_type_t;
 
 /** struct sensors_vec_s is used to return a vector in a common format. */
@@ -171,6 +172,7 @@ typedef struct {
                                the air (Ohms) */
     float unitless_percent; /**<Percentage, unit-less (%) */
     sensors_color_t color;  /**< color in RGB component values */
+    float altitude;         /**< Distance between a reference datum and a point or object, in meters. */
   };                        ///< Union for the wide ranges of data we can carry
 } sensors_event_t;
 

--- a/Adafruit_Sensor.h
+++ b/Adafruit_Sensor.h
@@ -172,8 +172,9 @@ typedef struct {
                                the air (Ohms) */
     float unitless_percent; /**<Percentage, unit-less (%) */
     sensors_color_t color;  /**< color in RGB component values */
-    float altitude;         /**< Distance between a reference datum and a point or object, in meters. */
-  };                        ///< Union for the wide ranges of data we can carry
+    float altitude; /**< Distance between a reference datum and a point or
+                       object, in meters. */
+  };                ///< Union for the wide ranges of data we can carry
 } sensors_event_t;
 
 /* Sensor details (40 bytes) */

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ typedef enum
   SENSOR_TYPE_PM25_ENV              = (27),
   SENSOR_TYPE_PM100_ENV             = (28),
   SENSOR_TYPE_GAS_RESISTANCE        = (29),
-  SENSOR_TYPE_UNITLESS_PERCENT      = (30)
+  SENSOR_TYPE_UNITLESS_PERCENT      = (30),
+  SENSOR_TYPE_ALTITUDE              = (31),
 } sensors_type_t;
 ```
 
@@ -163,6 +164,7 @@ typedef struct
         float           pm100_env,
         float           gas_resistance,
         float           unitless_percent,
+        float           altitude,
         sensors_color_t color;
     };
 } sensors_event_t;
@@ -218,6 +220,7 @@ A key part of the abstraction layer is the standardization of values on SI units
 - **pm100_env**: values are in **parts per million** (ppm)
 - **gas_resistance**: values are in **ohms**
 - **unitless_percent**: values are in **%**
+- **altitude**: values are in **meters** (m)
 
 ## The Unified Driver Abstraction Layer in Practice ##
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit Unified Sensor
-version=1.1.11
+version=1.1.12
 author=Adafruit <info@adafruit.com>
 maintainer=Adafruit <info@adafruit.com>
 sentence=Required for all Adafruit Unified Sensor based libraries.


### PR DESCRIPTION
Adds an altitude sensor type, used by sensors like BMP280 for determining a vertical distance between two points in meters.

Resolves https://github.com/adafruit/Adafruit_Sensor/issues/52